### PR TITLE
Feat/add tags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,9 @@ repos:
     - id: ruff
       args: [ --fix ]
       stages: [pre-commit]
-      autostage: true
     # Run the formatter.
     - id: ruff-format
       stages: [pre-commit]
-      autostage: true
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
   rev: 0.7.2
@@ -30,7 +28,7 @@ repos:
   hooks:
     - id: pytest
       name: pytest
-      entry: uv run pytest journal_ai/tests/
+      entry: uv run pytest --doctest-modules
       language: system
       pass_filenames: false
       always_run: true

--- a/journal_ai/journal/journal.py
+++ b/journal_ai/journal/journal.py
@@ -18,7 +18,8 @@ class JournalManager:
     def create_entry(self, content: str) -> str:
         entries = self.storage.load_all()
         entry_id = str(len(entries) + 1)
-        self.storage.save_entry(entry_id, content)
+        entry = JournalEntry.create(content=content, entry_id=entry_id)
+        self.storage.save_entry(entry)
         return entry_id
 
     def view_entries(self) -> Dict[str, JournalEntry]:
@@ -35,7 +36,7 @@ class JournalManager:
     def edit_entry(self, entry_id: str, content: str) -> bool:
         existing_entry = self.storage.load_entry(entry_id)
         if existing_entry is not None:
-            self.storage.save_entry(entry_id, content, existing_entry)
+            self.storage.save_entry(existing_entry)
             return True
         return False
 

--- a/journal_ai/journal/journal.py
+++ b/journal_ai/journal/journal.py
@@ -36,6 +36,7 @@ class JournalManager:
     def edit_entry(self, entry_id: str, content: str) -> bool:
         existing_entry = self.storage.load_entry(entry_id)
         if existing_entry is not None:
+            existing_entry.content = content
             self.storage.save_entry(existing_entry)
             return True
         return False

--- a/journal_ai/journal/models.py
+++ b/journal_ai/journal/models.py
@@ -1,11 +1,11 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from typing import List, Optional
 
 import numpy as np
 
 from journal_ai.config import Config
-from journal_ai.utils import generate_title
+from journal_ai.utils import generate_tags, generate_title
 
 
 @dataclass
@@ -17,7 +17,7 @@ class JournalEntry:
     updated_at: datetime
     id: Optional[str] = None
     title: Optional[str] = None
-    tags: List[str] = field(default_factory=list)
+    tags: Optional[List[str]] = None
     word_count: int = 0
     embedding: Optional[np.ndarray] = None
 
@@ -34,6 +34,7 @@ class JournalEntry:
         config: Optional[Config] = None,
         created_at=None,
         updated_at=None,
+        tags: Optional[List[str]] = None,
         **kwargs,
     ):
         """Factory method to create a new journal entry"""
@@ -45,12 +46,18 @@ class JournalEntry:
         if not generated_title and config:
             generated_title = generate_title(content, config)
 
+        if not tags and config:
+            tags = generate_tags(content, config)
+        else:
+            tags = tags or []
+
         return cls(
             content=content,
             created_at=created_time,
             updated_at=updated_time,
             id=entry_id,
             title=generated_title,
+            tags=tags,
             **kwargs,
         )
 

--- a/journal_ai/journal/models.py
+++ b/journal_ai/journal/models.py
@@ -4,9 +4,14 @@ from typing import List, Optional
 
 import numpy as np
 
+from journal_ai.config import Config
+from journal_ai.utils import generate_title
+
 
 @dataclass
 class JournalEntry:
+    """Class representing a journal entry."""
+
     content: str
     created_at: datetime
     updated_at: datetime
@@ -15,6 +20,39 @@ class JournalEntry:
     tags: List[str] = field(default_factory=list)
     word_count: int = 0
     embedding: Optional[np.ndarray] = None
+
+    def __post_init__(self):
+        if not self.word_count:
+            self.word_count = len(self.content.split())
+
+    @classmethod
+    def create(
+        cls,
+        content: str,
+        entry_id: Optional[str] = None,
+        title: Optional[str] = None,
+        config: Optional[Config] = None,
+        created_at=None,
+        updated_at=None,
+        **kwargs,
+    ):
+        """Factory method to create a new journal entry"""
+        now = datetime.now()
+        created_time = created_at or now
+        updated_time = updated_at or now
+
+        generated_title = title
+        if not generated_title and config:
+            generated_title = generate_title(content, config)
+
+        return cls(
+            content=content,
+            created_at=created_time,
+            updated_at=updated_time,
+            id=entry_id,
+            title=generated_title,
+            **kwargs,
+        )
 
     def to_dict(self):
         return {

--- a/journal_ai/journal/tags.py
+++ b/journal_ai/journal/tags.py
@@ -1,0 +1,36 @@
+import re
+from typing import List
+
+
+def generate_tags(content: str) -> List[str]:
+    """Generate tags from content that use @ to indicate a tag.
+
+    Args:
+        content (str): The content from which to generate tags.
+
+    Returns:
+        List[str]: A list of generated tags.
+
+    Example:
+        >>> content = "This is a test journal entry with tags @journal @writing @test."
+        >>> generate_tags(content)
+        ['journal', 'writing', 'test']
+        >>> content = "No tags here"
+        >>> generate_tags(content)
+        []
+        >>>
+    """
+    # Find all @ followed by word characters, then filter for valid tags
+    tag_pattern = r"(\s|^)@(\w+)(?=\s|[.,!?;:]|$)"
+    matches = re.findall(tag_pattern, content)
+
+    # Extract just the tag name from each match (second group)
+    tags = [match[1] for match in matches]
+
+    return tags
+
+
+if __name__ == "__main__":
+    # Example usage
+    content = "This is a test journal entry with tags @journal @writing @test."
+    print(generate_tags(content))  # Output: ['journal', 'writing', 'test']

--- a/journal_ai/logger.py
+++ b/journal_ai/logger.py
@@ -1,0 +1,12 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+handler = logging.StreamHandler()
+
+fmt = "%(levelname)s %(asctime)s %(filename)s %(funcName)s %(lineno)d %(message)s"
+formatter = logging.Formatter(fmt)
+handler.setFormatter(formatter)
+
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)

--- a/journal_ai/rag.py
+++ b/journal_ai/rag.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional
 
-import faiss
+import faiss  # type: ignore
 import numpy as np
 from openai import OpenAI
 
@@ -56,7 +56,7 @@ class RAGQuerier:
             self.index = faiss.IndexFlatL2(dimension)
             if self.index is not None:
                 embedding_array = np.array(embeddings, dtype=np.float32)
-                self.index.add(embedding_array, len(embeddings))
+                self.index.add(embedding_array)  # type: ignore
                 self._save_index()
 
     def query(self, question: str, k: int = 3) -> str:

--- a/journal_ai/rag.py
+++ b/journal_ai/rag.py
@@ -43,13 +43,7 @@ class RAGQuerier:
         for entry in self.entries:
             if not entry.embedding:
                 entry.embedding = self._get_embedding(entry.content)
-                if entry.id is not None:
-                    self.storage.save_entry(
-                        entry.id, entry.content, existing_entry=entry
-                    )
-
-            if entry.embedding:
-                embeddings.append(np.array(entry.embedding, dtype=np.float32))
+            embeddings.append(np.array(entry.embedding, dtype=np.float32))
 
         if embeddings:
             dimension = len(embeddings[0])

--- a/journal_ai/storage.py
+++ b/journal_ai/storage.py
@@ -1,11 +1,9 @@
 import json
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional
 
 from journal_ai.config import Config
 from journal_ai.journal.models import JournalEntry
-from journal_ai.utils import generate_title
 
 
 class JsonStorage:
@@ -19,17 +17,17 @@ class JsonStorage:
         self.directory.mkdir(parents=True, exist_ok=True)
         self.entry_directory.mkdir(parents=True, exist_ok=True)
 
-    def _get_entry_path(self, entry_id: str) -> Path:
-        return self.entry_directory / f"{entry_id}.json"
+    def _get_entry_path(self, id: str) -> Path:
+        return self.entry_directory / f"{id}.json"
 
     def get_vector_db_path(self) -> Path:
         return self.directory / "vector.index"
 
-    def load_entry(self, entry_id: str) -> Optional[JournalEntry]:
+    def load_entry(self, id: str) -> Optional[JournalEntry]:
         try:
-            with open(self._get_entry_path(entry_id), "r") as f:
+            with open(self._get_entry_path(id), "r") as f:
                 data = json.load(f)
-                data["id"] = entry_id
+                data["id"] = id
                 return JournalEntry.from_dict(data)
         except FileNotFoundError:
             return None
@@ -37,47 +35,26 @@ class JsonStorage:
     def load_all(self) -> Dict[str, JournalEntry]:
         entries = {}
         for file_path in self.entry_directory.glob("*.json"):
-            entry_id = file_path.stem
+            id = file_path.stem
             with open(file_path, "r") as f:
                 data = json.load(f)
-                data["id"] = entry_id
-                entries[entry_id] = JournalEntry.from_dict(data)
+                data["id"] = id
+                entries[id] = JournalEntry.from_dict(data)
         return entries
 
     def save_entry(
         self,
-        entry_id: str,
-        content: str,
-        existing_entry: Optional[JournalEntry] = None,
-        title: Optional[str] = None,
+        entry: JournalEntry,
     ):
-        now = datetime.now()
-        if existing_entry:
-            entry = JournalEntry(
-                content=content,
-                created_at=existing_entry.created_at,
-                updated_at=now,
-                id=entry_id,
-                title=title or existing_entry.title,
-                tags=existing_entry.tags,
-                embedding=existing_entry.embedding,
-            )
-        else:
-            generated_title = title or generate_title(content, self.config)
-            entry = JournalEntry(
-                content=content,
-                created_at=now,
-                updated_at=now,
-                id=entry_id,
-                title=generated_title,
-            )
+        if entry.id is None:
+            entry.id = str(len(self.load_all()) + 1)
 
-        with open(self._get_entry_path(entry_id), "w") as f:
+        with open(self._get_entry_path(entry.id), "w") as f:
             json.dump(entry.to_dict(), f, indent=2)
 
-    def delete_entry(self, entry_id: str) -> bool:
+    def delete_entry(self, id: str) -> bool:
         try:
-            self._get_entry_path(entry_id).unlink()
+            self._get_entry_path(id).unlink()
             return True
         except FileNotFoundError:
             return False

--- a/journal_ai/tests/journal/test_tags.py
+++ b/journal_ai/tests/journal/test_tags.py
@@ -1,0 +1,36 @@
+from journal_ai.journal.tags import generate_tags
+
+
+def test_generate_tags():
+    """Test the generate_tags function."""
+    content = "This is a test journal entry with tags @journal @writing @test"
+    expected_tags = ["journal", "writing", "test"]
+    assert generate_tags(content) == expected_tags
+
+
+def test_generate_tags_no_tags():
+    """Test the generate_tags function with no tags."""
+    content = "This is a test journal entry with no tags."
+    expected_tags = []
+    assert generate_tags(content) == expected_tags
+
+
+def test_generate_tags_no_content():
+    """Test the generate_tags function with no content."""
+    content = ""
+    expected_tags = []
+    assert generate_tags(content) == expected_tags
+
+
+def test_generate_tags_two_tags():
+    """Test the generate_tags function with two tags."""
+    content = "@tag1 @tag2"
+    expected_tags = ["tag1", "tag2"]
+    assert generate_tags(content) == expected_tags
+
+
+def test_email_in_content():
+    """Test the generate_tags function with an email in the content."""
+    content = "The email is test@test.com."
+    expected_tags = []
+    assert generate_tags(content) == expected_tags

--- a/journal_ai/tests/test_storage.py
+++ b/journal_ai/tests/test_storage.py
@@ -1,11 +1,15 @@
 from unittest.mock import patch
 
+from journal_ai.journal.models import JournalEntry
+from journal_ai.storage import JsonStorage
 
-@patch("journal_ai.storage.generate_title", return_value="Mock Title")
-def test_save_and_load_entry(mock_generate_title, storage):
+
+@patch("journal_ai.journal.models.generate_title", return_value="Mock Title")
+def test_save_and_load_entry(mock_generate_title, storage: JsonStorage):
     entry_id = "1"
     content = "Test content"
-    storage.save_entry(entry_id, content)
+    entry = JournalEntry.create(content=content, entry_id=entry_id)
+    storage.save_entry(entry)
 
     loaded_entry = storage.load_entry(entry_id)
     assert loaded_entry is not None
@@ -13,12 +17,13 @@ def test_save_and_load_entry(mock_generate_title, storage):
     assert loaded_entry.id == entry_id
 
 
-@patch("journal_ai.storage.generate_title", return_value="Mock Title")
-def test_load_all_entries(mock_generate_title, storage):
+@patch("journal_ai.journal.models.generate_title", return_value="Mock Title")
+def test_load_all_entries(mock_generate_title, storage: JsonStorage):
     entries = {"1": "First entry", "2": "Second entry", "3": "Third entry"}
 
     for entry_id, content in entries.items():
-        storage.save_entry(entry_id, content)
+        entry = JournalEntry.create(content=content, entry_id=entry_id)
+        storage.save_entry(entry)
 
     loaded_entries = storage.load_all()
     assert len(loaded_entries) == len(entries)
@@ -27,21 +32,25 @@ def test_load_all_entries(mock_generate_title, storage):
         assert loaded_entries[entry_id].content == content
 
 
-@patch("journal_ai.storage.generate_title", return_value="Mock Title")
-def test_delete_entry(mock_generate_title, storage):
+@patch("journal_ai.journal.models.generate_title", return_value="Mock Title")
+def test_delete_entry(mock_generate_title, storage: JsonStorage):
     entry_id = "1"
     content = "Test content"
-    storage.save_entry(entry_id, content)
+    entry = JournalEntry.create(content=content, entry_id=entry_id)
+    storage.save_entry(entry)
 
     assert storage.delete_entry(entry_id) is True
     assert storage.load_entry(entry_id) is None
     assert storage.delete_entry("non-existent") is False
 
 
-@patch("journal_ai.storage.generate_title", return_value="Mock Title")
-def test_purge(mock_generate_title, storage):
+@patch("journal_ai.journal.models.generate_title", return_value="Mock Title")
+def test_purge(mock_generate_title, storage: JsonStorage):
     for i in range(3):
-        storage.save_entry(str(i), f"Content {i}")
+        entry = JournalEntry.create(content=f"Content {i}", entry_id=str(i))
+        storage.save_entry(entry)
+
+    assert len(storage.load_all()) == 3
 
     storage.purge()
     assert len(storage.load_all()) == 0

--- a/journal_ai/tests/test_utils.py
+++ b/journal_ai/tests/test_utils.py
@@ -2,13 +2,24 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from journal_ai.utils import generate_title
+from journal_ai.utils import Tags, generate_tags, generate_title
 
 
 @pytest.fixture
 def mock_openai_response():
     mock_response = Mock()
     mock_response.choices = [Mock(message=Mock(content="Generated Title"))]
+    return mock_response
+
+
+@pytest.fixture
+def mock_openai_tags_response():
+    mock_response = Mock()
+    mock_choice = Mock()
+    mock_message = Mock()
+    mock_message.parsed = Tags(tags=["journal", "writing", "test"])
+    mock_choice.message = mock_message
+    mock_response.choices = [mock_choice]
     return mock_response
 
 
@@ -36,3 +47,40 @@ def test_generate_title_error(mock_openai_class, mock_config):
 
     assert title == "Untitled Entry"
     mock_client.chat.completions.create.assert_called_once()
+
+
+@patch("journal_ai.utils.OpenAI")
+def test_generate_tags(mock_openai_class, mock_openai_tags_response, mock_config):
+    mock_client = Mock()
+    mock_client.beta.chat.completions.parse.return_value = mock_openai_tags_response
+    mock_openai_class.return_value = mock_client
+
+    content = "This is a test journal entry"
+    tags = generate_tags(content, mock_config)
+
+    assert tags == ["journal", "writing", "test"]
+    mock_client.beta.chat.completions.parse.assert_called_once()
+
+
+@patch("journal_ai.utils.OpenAI")
+def test_generate_tags_error(mock_openai_class, mock_config):
+    mock_client = Mock()
+    mock_client.beta.chat.completions.parse.side_effect = Exception("API Error")
+    mock_openai_class.return_value = mock_client
+
+    content = "This is a test journal entry"
+    tags = generate_tags(content, mock_config)
+
+    assert tags == []
+    mock_client.beta.chat.completions.parse.assert_called_once()
+
+
+@patch("journal_ai.utils.OpenAI")
+def test_generate_tags_no_api_key(mock_openai_class, mock_config):
+    mock_config.openai_api_key = None
+
+    content = "This is a test journal entry"
+    tags = generate_tags(content, mock_config)
+
+    assert tags == []
+    mock_openai_class.assert_not_called()

--- a/journal_ai/utils.py
+++ b/journal_ai/utils.py
@@ -1,8 +1,16 @@
-from typing import Optional
+from typing import List, Optional
 
 from openai import OpenAI
+from pydantic import BaseModel, Field
 
 from journal_ai.config import Config
+from journal_ai.logger import logger
+
+
+class Tags(BaseModel):
+    tags: List[str] = Field(
+        description="A list of tags of entities and actions in the text."
+    )
 
 
 def generate_title(content: str, config: Optional[Config] = None) -> str:
@@ -21,8 +29,7 @@ def generate_title(content: str, config: Optional[Config] = None) -> str:
         client = OpenAI(api_key=config.openai_api_key)
 
         prompt = (
-            "Generate a short, engaging title (max 5 words) for this journal entry:\n\n"
-            f"{content}"
+            f"Generate a short title (max 5 words) for this journal entry:\n\n{content}"
         )
 
         try:
@@ -42,3 +49,59 @@ def generate_title(content: str, config: Optional[Config] = None) -> str:
             return "Untitled Entry"
     else:
         return "Untitled Entry"
+
+
+def generate_tags(content: str, config: Optional[Config] = None) -> List[str]:
+    """
+    Generate tags for the journal entry using OpenAI's API.
+    Args:
+        content (str): The content of the journal entry.
+    Returns:
+        str: The generated tags.
+    """
+
+    if config is None:
+        config = Config.from_env()
+    if config.openai_api_key:
+        prompt = """Generate a list of tags for journal entries.
+        The tags can include entities and actions.
+        The tags should not include adjectives or adverbs."""
+
+        messages = [
+            {"role": "system", "content": prompt},
+            {
+                "role": "user",
+                "content": content,
+            },
+        ]
+        try:
+            client = OpenAI(api_key=config.openai_api_key)
+
+            response = client.beta.chat.completions.parse(
+                model=config.model,
+                messages=messages,  # type: ignore
+                response_format=Tags,
+            )
+
+            parsed_response = response.choices[0].message.parsed
+            if not parsed_response:
+                return []
+            if isinstance(parsed_response, Tags):
+                return parsed_response.tags
+            else:
+                raise ValueError(f"Unexpected response format: {type(parsed_response)}")
+        except Exception as e:
+            logger.error(f"Error generating tags: {str(e)}")
+            return []
+    else:
+        return []
+
+
+if __name__ == "__main__":
+    # Example usage
+    content = "The dog barked loudly at the mailman, Dave."
+    config = Config.from_env()
+    title = generate_title(content, config)
+    tags = generate_tags(content, config)
+    print(f"Generated Title: {title}")
+    print(f"Generated Tags: {tags}")

--- a/journal_ai/utils.py
+++ b/journal_ai/utils.py
@@ -57,7 +57,7 @@ def generate_tags(content: str, config: Optional[Config] = None) -> List[str]:
     Args:
         content (str): The content of the journal entry.
     Returns:
-        str: The generated tags.
+        List[str]: The generated tags.
     """
 
     if config is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ line-ending = "auto"
 
 [tool.pytest.ini_options]
 testpaths = [
-    "journal_ai/tests",
+    "journal_ai/"
 ]
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
# Contributions

- Added the capability to tag entries manually using `@tag`.
- OpenAI is also used to generate automatic tags.
- Running `pytest --doctest-modules` now. This allows tests to be in docstrings.
- Added a  shared`logger.py` object.
- Refactored the entry handling to happen in the journal class and not in storage.